### PR TITLE
Fix bug #2224

### DIFF
--- a/dbgpt/serve/rag/connector.py
+++ b/dbgpt/serve/rag/connector.py
@@ -3,6 +3,7 @@
 import copy
 import logging
 import os
+import chromadb
 from collections import defaultdict
 from typing import Any, DefaultDict, Dict, List, Optional, Tuple, Type, cast
 
@@ -224,6 +225,8 @@ class VectorStoreConnector:
         try:
             if self.vector_name_exists():
                 self.client.delete_vector_name(vector_name)
+                chromadb.api.client.SharedSystemClient.clear_system_cache()
+                del pools[self._vector_store_type][vector_name]
         except Exception as e:
             logger.error(f"delete vector name {vector_name} failed: {e}")
             raise Exception(f"delete name {vector_name} failed")


### PR DESCRIPTION
# Description

解决多次创建同一个数据库，存储元数据的向量库不被创建的问题

# How Has This Been Tested?

多次添加删除同一个数据库

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have already rebased the commits and make the commit message conform to the project standard.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
